### PR TITLE
Added contentId prop. Added its usage and basic editor usage in Svelte.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ It is easier to import and work directly from the source if you are using Svelte
 
 To limit the tools shown in the toolbar, pass in an `actions` prop, eg. `actions={["b", "i", "u", "h2", "ul", "left", "center", "justify", "forecolor"]}`.
 
-To easily get the editor DOM element, pass an `editorId` prop, eg. `editorId='notes-editor'`.
+To easily get the editor content DOM element, pass an `contentId` prop, eg. `contentId='notes-content'`.
 
 This is useful if you want to listen to resize of the editor and respond accordingly.
 
@@ -138,10 +138,10 @@ Now observe the resize:
     // resond to contentWd ...
   })
   let editor
-  $: editor && ro.observe(document.getElementById('notes-editor'))
+  $: editor && ro.observe(document.getElementById('notes-content'))
 </script>
 
-<Editor { ...otherEditorCfgs editorId='notes-editor' bind:this={editor} />
+<Editor { ...otherEditorCfgs contentId='notes-content' bind:this={editor} />
 ```
 
 #### Run demo

--- a/README.md
+++ b/README.md
@@ -98,6 +98,52 @@ editor.$on('blur', (event) => console.log(event)) // on editor blur event
 editor.refs.<editor | raw | modal | colorPicker> // references to editor, raw (textarea), modal and colorPicker HTMLElements
 ```
 
+#### Usage in Svelte
+
+It is easier to import and work directly from the source if you are using Svelte. You can handle `change` events via `on:change`.
+
+```jsx
+<script>
+  import Editor from "cl-editor/src/Editor.svelte"
+
+  let html = '<h3>hello</h3>'
+  let editor
+
+</script>
+
+{@html html}
+<Editor {html} on:change={(evt)=>html = evt.detail}
+```
+
+To limit the tools shown in the toolbar, pass in an `actions` prop, eg. `actions={["b", "i", "u", "h2", "ul", "left", "center", "justify", "forecolor"]}`.
+
+To easily get the editor DOM element, pass an `editorId` prop, eg. `editorId='notes-editor'`.
+
+This is useful if you want to listen to resize of the editor and respond accordingly.
+
+To do so, first enable resize on the editor:
+
+```css
+.cl-content {
+  resize: both;
+}
+```
+
+Now observe the resize:
+
+```jsx
+<script>
+  const ro = new ResizeObserver(entries => {
+    const contentWd = entries[0].contentRect.width
+    // resond to contentWd ...
+  })
+  let editor
+  $: editor && ro.observe(document.getElementById('notes-editor'))
+</script>
+
+<Editor { ...otherEditorCfgs editorId='notes-editor' bind:this={editor} />
+```
+
 #### Run demo
 ```bash
 git clone https://github.com/nenadpnc/cl-text-editor.git cl-editor

--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -16,7 +16,7 @@
     {/each}
   </div>
   <div bind:this={$references.editor}
-    id="{editorId}"
+    id="{contentId}"
     class="cl-content"
     style="height: {height}"
     contenteditable="true"
@@ -57,7 +57,7 @@
   export let actions = [];
   export let height = '300px';
   export let html = '';
-  export let editorId = '';
+  export let contentId = '';
   export let removeFormatTags = ['h1', 'h2', 'blockquote']
 
   let helper = writable({

--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -16,6 +16,7 @@
     {/each}
   </div>
   <div bind:this={$references.editor}
+    id="{editorId}"
     class="cl-content"
     style="height: {height}"
     contenteditable="true"
@@ -41,7 +42,7 @@
     getNewActionObj,
     removeBadTags,
     isEditorClick
-} from './helpers/util.js';
+  } from './helpers/util.js';
 
   import defaultActions from './helpers/actions.js';
   import EditorModal from './helpers/EditorModal.svelte';
@@ -56,8 +57,8 @@
   export let actions = [];
   export let height = '300px';
   export let html = '';
+  export let editorId = '';
   export let removeFormatTags = ['h1', 'h2', 'blockquote']
-
 
   let helper = writable({
       foreColor: false,


### PR DESCRIPTION
There is not a way to set an id for the content div, this PR adds that ability. Usage and basic editor usage that were answered in Issues has been added in README.