### PR TITLE
Configure colours from svelte component

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ It is easier to import and work directly from the source if you are using Svelte
 <Editor {html} on:change={(evt)=>html = evt.detail}/>
 ```
 
+### Example of customising the color picker palette 
+
+```jsx
+<script>
+  import Editor from "cl-editor/src/Editor.svelte"
+
+  let html = '<h3>hello</h3>'
+  let colors = ['#000000', '#e60000', '#ff9900', '#ffff00', '#008a00', '#0066cc', '#9933ff',
+        '#ffffff', '#facccc', '#ffebcc', '#ffffcc', '#cce8cc', '#cce0f5', '#ebd6ff',
+        '#bbbbbb', '#f06666', '#ffc266', '#ffff66', '#66b966', '#66a3e0', '#c285ff',
+        '#888888', '#a10000', '#b26b00', '#b2b200', '#006100', '#0047b2', '#6b24b2',
+        '#444444', '#5c0000', '#663d00', '#666600', '#003700', '#002966', '#3d1466']
+  let editor
+
+</script>
+
+{@html html}
+<Editor {html} {colors} on:change={(evt)=>html = evt.detail}/>
+```
+
 To limit or define the tools shown in the toolbar, pass in an `actions` prop.
 
 To easily get the editor content DOM element, pass an `contentId` prop, eg. `contentId='notes-content'`.

--- a/src/Editor.svelte
+++ b/src/Editor.svelte
@@ -28,7 +28,7 @@
 
   <textarea bind:this={$references.raw} class="cl-textarea" style="max-height: {height}; min-height: {height}"></textarea>
   <EditorModal bind:this={$references.modal}></EditorModal>
-  <EditorColorPicker bind:this={$references.colorPicker}></EditorColorPicker>
+  <EditorColorPicker bind:this={$references.colorPicker} {colors}></EditorColorPicker>
 </div>
 
 <script>
@@ -58,6 +58,7 @@
   export let height = '300px';
   export let html = '';
   export let contentId = '';
+  export let colors = ['#ffffff', '#000000', '#eeece1', '#1f497d', '#4f81bd', '#c0504d', '#9bbb59', '#8064a2', '#4bacc6', '#f79646', '#ffff00', '#f2f2f2', '#7f7f7f', '#ddd9c3', '#c6d9f0', '#dbe5f1', '#f2dcdb', '#ebf1dd', '#e5e0ec', '#dbeef3', '#fdeada', '#fff2ca', '#d8d8d8', '#595959', '#c4bd97', '#8db3e2', '#b8cce4', '#e5b9b7', '#d7e3bc', '#ccc1d9', '#b7dde8', '#fbd5b5', '#ffe694', '#bfbfbf', '#3f3f3f', '#938953', '#548dd4', '#95b3d7', '#d99694', '#c3d69b', '#b2a2c7', '#b7dde8', '#fac08f', '#f2c314', '#a5a5a5', '#262626', '#494429', '#17365d', '#366092', '#953734', '#76923c', '#5f497a', '#92cddc', '#e36c09', '#c09100', '#7f7f7f', '#0c0c0c', '#1d1b10', '#0f243e', '#244061', '#632423', '#4f6128', '#3f3151', '#31859b', '#974806', '#7f6000']
   export let removeFormatTags = ['h1', 'h2', 'blockquote']
 
   let helper = writable({

--- a/src/helpers/EditorColorPicker.svelte
+++ b/src/helpers/EditorColorPicker.svelte
@@ -11,17 +11,17 @@
     import {onMount, createEventDispatcher } from "svelte";
 
     const dispatcher = new createEventDispatcher();
-    const colors = ['ffffff', '000000', 'eeece1', '1f497d', '4f81bd', 'c0504d', '9bbb59', '8064a2', '4bacc6', 'f79646', 'ffff00', 'f2f2f2', '7f7f7f', 'ddd9c3', 'c6d9f0', 'dbe5f1', 'f2dcdb', 'ebf1dd', 'e5e0ec', 'dbeef3', 'fdeada', 'fff2ca', 'd8d8d8', '595959', 'c4bd97', '8db3e2', 'b8cce4', 'e5b9b7', 'd7e3bc', 'ccc1d9', 'b7dde8', 'fbd5b5', 'ffe694', 'bfbfbf', '3f3f3f', '938953', '548dd4', '95b3d7', 'd99694', 'c3d69b', 'b2a2c7', 'b7dde8', 'fac08f', 'f2c314', 'a5a5a5', '262626', '494429', '17365d', '366092', '953734', '76923c', '5f497a', '92cddc', 'e36c09', 'c09100', '7f7f7f', '0c0c0c', '1d1b10', '0f243e', '244061', '632423', '4f6128', '3f3151', '31859b', '974806', '7f6000']
-
-    const getBtns = () => {
-      const btns = colors.map((color) => ({ color: `#${color}` }));
-      btns.push({ text: '#', modal: true });
-      return btns;
-    }
 
     export let show = false;
     export let btns = [];
     export let event = '';
+    export let colors = [];
+
+    const getBtns = () => {
+      const btns = colors.map((color) => ({ color }));
+      btns.push({ text: '#', modal: true });
+      return btns;
+    }
 
     onMount(() => {
         btns = getBtns();

--- a/src/helpers/actions.js
+++ b/src/helpers/actions.js
@@ -268,7 +268,6 @@ export default {
 const showColorPicker = function(cmd) {
 	const refs = get(this.references);
 	saveRange(refs.editor);
-	console.log(refs.colorPicker);
 	refs.colorPicker.$set({show: true, event: cmd});
 	if (!get(this.helper)[cmd]) {
 		this.helper.update(state => {


### PR DESCRIPTION
I've moved a few things around to allow you to push colours from a variable, I've also switched to hash colour codes as that makes it easier to see the colours in things like vscode

![image](https://user-images.githubusercontent.com/22966791/144201814-c5f373b0-38d4-48a0-bee5-9d7452a5e302.png)