### PR TITLE
Reactive Colours and Modal tweaks

### DIFF
--- a/src/helpers/EditorColorPicker.svelte
+++ b/src/helpers/EditorColorPicker.svelte
@@ -18,9 +18,10 @@
     export let colors = [];
 
     $: {
-        btns = colors.map((color) => ({ color }));
-        btns.push({ text: '#', modal: true });
-    };
+        btns = colors
+            .map((color) => ({ color }))
+            .concat([{ text: '#', modal: true }]);
+    }
 
     function close() {
         show = false;

--- a/src/helpers/EditorColorPicker.svelte
+++ b/src/helpers/EditorColorPicker.svelte
@@ -8,7 +8,7 @@
 </div>
 
 <script>
-    import {onMount, createEventDispatcher } from "svelte";
+    import { createEventDispatcher } from "svelte";
 
     const dispatcher = new createEventDispatcher();
 
@@ -17,15 +17,10 @@
     export let event = '';
     export let colors = [];
 
-    const getBtns = () => {
-      const btns = colors.map((color) => ({ color }));
-      btns.push({ text: '#', modal: true });
-      return btns;
-    }
-
-    onMount(() => {
-        btns = getBtns();
-    });
+    $: {
+        btns = colors.map((color) => ({ color }));
+        btns.push({ text: '#', modal: true });
+    };
 
     function close() {
         show = false;

--- a/src/helpers/EditorColorPicker.svelte
+++ b/src/helpers/EditorColorPicker.svelte
@@ -17,11 +17,9 @@
     export let event = '';
     export let colors = [];
 
-    $: {
-        btns = colors
+    $: btns = colors
             .map((color) => ({ color }))
             .concat([{ text: '#', modal: true }]);
-    }
 
     function close() {
         show = false;

--- a/src/helpers/EditorModal.svelte
+++ b/src/helpers/EditorModal.svelte
@@ -1,24 +1,24 @@
 <svelte:options accessors={true}></svelte:options>
 {#if show}
-	<div class="cl-editor-overlay" on:click="{cancel}"></div>
-	<div class="cl-editor-modal">
-		<div class="modal-box">
-		  <span class="modal-title">{title}</span>
-		  <form on:submit|preventDefault="{event=>confirm()}">
-			  <label class="modal-label" class:input-error={error}>
-			  <input bind:this={refs.text} on:keyup="{hideError}" use:inputType name="text" bind:value="{text}">
-			  <span class="input-info">
-          <span>{label}</span>
-          {#if error}
+  <div class="cl-editor-overlay" on:click="{cancel}"></div>
+  <div class="cl-editor-modal">
+    <div class="modal-box">
+      <span class="modal-title">{title}</span>
+      <form on:submit|preventDefault="{event=>confirm()}">
+        <label class="modal-label" class:input-error={error}>
+          <input bind:this={refs.text} on:keyup="{hideError}" use:inputType name="text" bind:value="{text}">
+          <span class="input-info">
+            <span>{label}</span>
+            {#if error}
             <span class="msg-error">Required</span>
-          {/if}
-			  </span>
-			</label>
-			<button class="modal-button modal-submit" type="submit">Confirm</button>
-			<button class="modal-button modal-reset" type="reset" on:click="{cancel}">Cancel</button>
-		  </form>
-		</div>
-	</div>
+            {/if}
+          </span>
+        </label>
+        <button class="modal-button modal-submit" type="submit">Confirm</button>
+        <button class="modal-button modal-reset" type="reset" on:click="{cancel}">Cancel</button>
+      </form>
+    </div>
+  </div>
 {/if}
 
 <script>

--- a/src/helpers/EditorModal.svelte
+++ b/src/helpers/EditorModal.svelte
@@ -1,28 +1,28 @@
 <svelte:options accessors={true}></svelte:options>
-<div style="display: {show ? 'block' : 'none'}">
-  <div class="cl-editor-overlay" on:click="{cancel}"></div>
-  <div class="cl-editor-modal">
-    <div class="modal-box">
-      <span class="modal-title">{title}</span>
-      <form on:submit|preventDefault="{event=>confirm()}">
-        <label class="modal-label" class:input-error={error}>
-          <input bind:this={refs.text} on:keyup="{hideError}" type="text" name="text" bind:value="{text}">
-          <span class="input-info">
-            <span>{label}</span>
-            {#if error}
+{#if show}
+	<div class="cl-editor-overlay" on:click="{cancel}"></div>
+	<div class="cl-editor-modal">
+		<div class="modal-box">
+		  <span class="modal-title">{title}</span>
+		  <form on:submit|preventDefault="{event=>confirm()}">
+			  <label class="modal-label" class:input-error={error}>
+			  <input bind:this={refs.text} on:keyup="{hideError}" use:inputType name="text" bind:value="{text}">
+			  <span class="input-info">
+          <span>{label}</span>
+          {#if error}
             <span class="msg-error">Required</span>
-            {/if}
-          </span>
-        </label>
-        <button class="modal-button modal-submit" type="submit">Confirm</button>
-        <button class="modal-button modal-reset" type="reset" on:click="{cancel}">Cancel</button>
-      </form>
-    </div>
-  </div>
-</div>
+          {/if}
+			  </span>
+			</label>
+			<button class="modal-button modal-submit" type="submit">Confirm</button>
+			<button class="modal-button modal-reset" type="reset" on:click="{cancel}">Cancel</button>
+		  </form>
+		</div>
+	</div>
+{/if}
 
 <script>
-  import {onMount, createEventDispatcher } from "svelte";
+  import { createEventDispatcher } from "svelte";
 
   let dispatcher = new createEventDispatcher();
 
@@ -34,6 +34,10 @@
   export let error = false;
 
   let refs = {}
+  
+  const inputType = (e) => {
+	  e.type = event === 'colorHref' ? 'color' : 'text';
+  };
 
   $:{
     if(show){
@@ -42,7 +46,6 @@
       });
     }
   }
-
 
   function confirm() {
     if (text) {
@@ -132,7 +135,7 @@
   position: absolute;
   top: 0;
   right: 0;
-  height: 27px;
+  height: 29px;
   line-height: 25px;
   border: 1px solid #DEDEDE;
   background: #fff;

--- a/src/helpers/EditorModal.svelte
+++ b/src/helpers/EditorModal.svelte
@@ -36,7 +36,7 @@
   let refs = {}
   
   const inputType = (e) => {
-	  e.type = event === 'colorHref' ? 'color' : 'text';
+    e.type = event === 'colorHref' ? 'color' : 'text';
   };
 
   $:{


### PR DESCRIPTION
Updates in this pull request

- colours change reactively when colors variable changes from outside of the plugin, this allows you to use sessions to sync colour pallets across multiple editors and dynamically add colours as they are used
- added native color picker to the modal input by switching out the input type depending on if its a color picker needed (detected by event type)
- only load the modal html when its needed not on runtime to facilitate the above and save extra html load when may not be needed, rather than the current show/hide type.

![image](https://user-images.githubusercontent.com/22966791/144461461-e9103eab-db1a-414b-afdb-b2c381b02bbf.png)

